### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "moment": "^2.24.0",
     "node-sass": "^4.12.0",
     "normalize.css": "7.0.0",
-    "npm": "^6.9.0",
     "react": "^16.7.0",
     "react-dom": "^16.8.6",
     "react-redux": "^5.1.1",


### PR DESCRIPTION

Hello wildee14!

It seems like you have npm as one of your (dev-) dependency in degree-mastery.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
